### PR TITLE
Each panel in VolumeViewer emits a "draw" event when drawing.

### DIFF
--- a/src/brainbrowser/lib/events.js
+++ b/src/brainbrowser/lib/events.js
@@ -74,9 +74,7 @@
       var args = Array.prototype.slice.call(arguments, 1);
       if (event_listeners[event]) {
         event_listeners[event].forEach(function(callback) {
-          setTimeout(function() {
-            callback.apply(null, args);
-          }, 0);
+          callback.apply(null, args);
         });
       }
     }

--- a/src/brainbrowser/volume-viewer.js
+++ b/src/brainbrowser/volume-viewer.js
@@ -290,6 +290,7 @@
     * * **rendering** Viewer has started rendering.
     * * **volumeuiloaded** A new volume UI has been created by the viewer.
     * * **sliceupdate** A new slice has been rendered to the viewer.
+    * * **draw** A panel is being re-drawn.
     * * **error** An error has occured.
     *
     * To listen for an event, simply use the viewer's **addEventListener()** method with
@@ -362,6 +363,20 @@
     *
     * ```js
     *    BrainBrowser.events.addEventListener("sliceupdate", function() {
+    *      //...
+    *    });
+    * ```
+    */
+    /**
+    * @doc object
+    * @name VolumeViewer.events:draw
+    *
+    * @description
+    * Triggered when a panel currently being displayed is re-drawn.
+    * The event handler receives two arguments: the volume and the panel.
+    *
+    * ```js
+    *    BrainBrowser.events.addEventListener("draw", function(volume, panel) {
     *      //...
     *    });
     * ```

--- a/src/brainbrowser/volume-viewer/modules/rendering.js
+++ b/src/brainbrowser/volume-viewer/modules/rendering.js
@@ -69,6 +69,8 @@ BrainBrowser.VolumeViewer.modules.rendering = function(viewer) {
           );
           context.restore();
         }
+
+        BrainBrowser.events.triggerEvent("draw", volume, panel);
       });
     });
   };
@@ -89,7 +91,7 @@ BrainBrowser.VolumeViewer.modules.rendering = function(viewer) {
 
     (function render() {
       window.requestAnimationFrame(render);
-  
+
       viewer.draw();
     })();
   };


### PR DESCRIPTION
This pull request is a step towards fixing #94.

This allows for custom code to be executed on panel refresh, allowing the user to draw something else on the canvas.
Here is an example:

``` diff
diff --git a/examples/volume-viewer-demo.js b/examples/volume-viewer-demo.js
index ad3fa08..a0d5b40 100644
--- a/examples/volume-viewer-demo.js
+++ b/examples/volume-viewer-demo.js
@@ -530,6 +530,22 @@ $(function() {
       }
     });

+    BrainBrowser.events.addEventListener("draw", function (volume, panel) {
+      if (panel.axis !== "yspace") return;
+      var context = panel.context;
+      context.save();
+      context.strokeStyle = "#EC2121";
+      context.lineWidth = 10;
+      context.strokeRect(
+        1 * 100,
+        1 * 100,
+        1 * 100,
+        1 * 100
+      );
+
+      context.restore();
+    });
+
     var color_map_config = BrainBrowser.config.get("color_maps")[0];

     loading_div.show();
```

which triggers the following display on the example page:
![capture decran 2014-08-11 a 14 39 44](https://cloud.githubusercontent.com/assets/1788596/3875782/674dcc36-2155-11e4-9589-ae8c3de8af90.png)

Please note that I had to trigger the event handlers synchronously, otherwise the code wasn't executed when it should and the canvas wasn't updated correctly (i.e. the red squares were not displayed because they were drawn too late). Notably, triggering events synchronously is what Node does: https://github.com/joyent/node/blob/master/lib/events.js#L100-L130 .

Any feedback is appreciated!
