### PR TITLE
Emit the "draw" event after drawing the slice and before drawing the cur...

### DIFF
--- a/src/brainbrowser/volume-viewer/modules/rendering.js
+++ b/src/brainbrowser/volume-viewer/modules/rendering.js
@@ -55,6 +55,7 @@ BrainBrowser.VolumeViewer.modules.rendering = function(viewer) {
 
         color_map = volume.color_map || viewer.default_color_map;
         panel.drawSlice();
+        BrainBrowser.events.triggerEvent("draw", volume, panel);
         panel.drawCursor(color_map.cursor_color);
 
         if (canvas === viewer.active_canvas) {
@@ -69,8 +70,6 @@ BrainBrowser.VolumeViewer.modules.rendering = function(viewer) {
           );
           context.restore();
         }
-
-        BrainBrowser.events.triggerEvent("draw", volume, panel);
       });
     });
   };


### PR DESCRIPTION
...sor.

In this way, the cursor will be drawn last, which means that it can't be hidden by custom user drawings.

This should fix #94!

Before / After
![capture decran 2014-08-11 a 15 53 54](https://cloud.githubusercontent.com/assets/1788596/3876772/5b7147bc-215f-11e4-99e8-81f58f68e620.png) ![capture decran 2014-08-11 a 15 54 07](https://cloud.githubusercontent.com/assets/1788596/3876773/5d7e2e08-215f-11e4-8e07-6ad1f8d0c6d4.png)
