### PR TITLE
VolumeViewer: Updating a panel.zoom property triggers the zoom event

### DIFF
--- a/src/brainbrowser/volume-viewer/lib/panel.js
+++ b/src/brainbrowser/volume-viewer/lib/panel.js
@@ -266,6 +266,12 @@
     },
 
     draw: function(cursor_color, active) {
+      if (this.old_zoom_level !== this.zoom) {
+        this.old_zoom_level = this.zoom;
+        this.updated = true;
+        BrainBrowser.events.triggerEvent("zoom", this.volume, this);
+      }
+
       if (!this.updated) {
         return;
       }
@@ -352,6 +358,7 @@
         y: 0
       },
       zoom: 1,
+      old_zoom_level: undefined,
       updated: true
     };
 

--- a/src/brainbrowser/volume-viewer/modules/loading.js
+++ b/src/brainbrowser/volume-viewer/modules/loading.js
@@ -671,12 +671,9 @@ BrainBrowser.VolumeViewer.modules.loading = function(viewer) {
                 var panel = volume.display[axis_num];
                 panel.zoom = Math.max(panel.zoom + delta * 0.05, 0.05);
                 viewer.fetchSlice(synced_vol_id, ["xspace", "yspace", "zspace"][axis_num]);
-                BrainBrowser.events.triggerEvent("zoom", volume, panel);
               }
             });
           }
-
-          BrainBrowser.events.triggerEvent("zoom", volume, panel);
         }
 
         canvas.addEventListener("mousewheel", wheelHandler, false);


### PR DESCRIPTION
I used the same dirty checking mechanism as in [the surface viewer](https://github.com/aces/brainbrowser/blob/f61329c3a4311b0864814932f529432ca1f2fe54/src/brainbrowser/surface-viewer/modules/rendering.js#L419-L423), except that the `old_zoom_level` is stored as a "private" (non-documented) property of a panel.

fix #122 
