### PR TITLE
Add volumeloaded event

### DIFF
--- a/src/brainbrowser/volume-viewer.js
+++ b/src/brainbrowser/volume-viewer.js
@@ -314,6 +314,21 @@
 
     /**
     * @doc object
+    * @name VolumeViewer.events:volumeloaded
+    *
+    * @description
+    * Triggered when a volume loaded through **viewer.loadVolume()** or one of the
+    * volumes loaded from **viewer.loadVolume()** has completely finished loading.
+    * The event handler receives the volume as sole argument.
+    *
+    * ```js
+    *    BrainBrowser.events.addEventListener("volumeloaded", function(volume) {
+    *      //...
+    *    });
+    * ```
+    */
+    /**
+    * @doc object
     * @name VolumeViewer.events:volumesloaded
     *
     * @description

--- a/src/brainbrowser/volume-viewer/modules/loading.js
+++ b/src/brainbrowser/volume-viewer/modules/loading.js
@@ -355,8 +355,11 @@ BrainBrowser.VolumeViewer.modules.loading = function(viewer) {
         var position = volume.position[axis] = Math.floor(volume.header[axis].space_length / 2);
         
         viewer.fetchSlice(vol_id, axis, position, function() {
-          if (++slices_loaded === 3 && BrainBrowser.utils.isFunction(callback)) {
-            callback(volume);
+          if (++slices_loaded === 3) {
+            BrainBrowser.events.triggerEvent("volumeloaded", volume);
+            if (BrainBrowser.utils.isFunction(callback)) {
+              callback(volume);
+            }
           }
         });
 


### PR DESCRIPTION
related to #114

Usage example, in `volume-viewer-demo.js`:

``` javascript
BrainBrowser.events.addEventListener("volumeloaded", function(volume) {
  console.log("volumeloaded", volume);
});
```

Result:
![image](https://cloud.githubusercontent.com/assets/1788596/4076387/b59dbe2a-2eb9-11e4-992a-719a74b39940.png)
