### PR TITLE
Minc2volume viewer export functions

### DIFF
--- a/scripts/minc2volume-viewer.js
+++ b/scripts/minc2volume-viewer.js
@@ -44,7 +44,7 @@
 var fs = require("fs");
 var exec =  require("child_process").exec;
 var spawn = require("child_process").spawn;
-var version = "0.2";
+var version = "0.3";
 
 if (require.main === module) {
   var filename = process.argv[2];


### PR DESCRIPTION
The `minc2volume-viewer.js` script is now able to export two javascript functions when it is `require()`d.

The original use case stays the same:

``` bash
  $ node minc2volume-viewer.js <filename>
```

But we can now use it as a module:

``` javascript
var minc2volumeViewer = require('./minc2volume-viewer')
minc2volumeViewer.getHeader('<filename>', function (err, header) {
  ...
})
var rawStream = minc2volumeViewer.getRawDataStream('<filename>')
rawStream.pipe(...)
rawStream.on('error', function (err) { ... })
```
