### PR TITLE
Defaults for intensity methods.

### DIFF
--- a/examples/surface-viewer-demo.js
+++ b/examples/surface-viewer-demo.js
@@ -564,7 +564,7 @@ $(function() {
     $("#pick-value").change(function() {
       var index = parseInt($("#pick-index").html(), 10);
       var value = parseFloat(this.value);
-      var intensity_data = viewer.model_data.get().intensity_data[0];
+      var intensity_data = viewer.model_data.getDefaultIntensityData();
 
       if (BrainBrowser.utils.isNumeric(index) && BrainBrowser.utils.isNumeric(value)) {
         viewer.setIntensity(intensity_data, index, value);
@@ -573,8 +573,7 @@ $(function() {
 
     $("#paint-value").change(function() {
       var value = parseFloat(this.value);
-      var model_data = viewer.model_data.get();
-      var intensity_data = model_data.intensity_data[0];
+      var intensity_data = viewer.model_data.getDefaultIntensityData();
 
       if (BrainBrowser.utils.isNumeric(value)) {
         $("#paint-color").css("background-color", "#" + viewer.color_map.colorFromValue(value, {

--- a/src/brainbrowser/surface-viewer/modules/color.js
+++ b/src/brainbrowser/surface-viewer/modules/color.js
@@ -103,7 +103,7 @@ BrainBrowser.SurfaceViewer.modules.color = function(viewer) {
   /** 
   * @doc function
   * @name viewer.color:setIntensity
-  * @param {object} intensity_data The data to update.
+  * @param {object} intensity\_data (Optional) The data to update.
   * @param {number} index Index at which to change the intensity value.
   * @param {number} value New intensity value.
   * @param {object} options Options for the range change, which include the following: 
@@ -114,11 +114,27 @@ BrainBrowser.SurfaceViewer.modules.color = function(viewer) {
   * ```js
   * viewer.setIntensity(intensity_data, 12124, 3.0);
   * ```
+  * Note that if this method is called without an explicit **intensity\_data**
+  * argument, it will update the first available intensity dataset.
+  * ```js
+  * viewer.setIntensity(12124, 3.0);
+  * ```
   */
-  viewer.setIntensity = function(intensity_data, index, value, options) {
-    options = options || {};
-    var model_data = intensity_data.model_data;
-    
+  viewer.setIntensity = function() {
+    var args = Array.prototype.slice.call(arguments);
+    var intensity_data, index, value, options, model_data;
+
+    if (!BrainBrowser.utils.isNumeric(args[0])) {
+      intensity_data = args.shift();
+    } else {
+      intensity_data = viewer.model_data.getDefaultIntensityData();
+    }
+    model_data = intensity_data.model_data;
+
+    index = args[0];
+    value = args[1];
+    options = args[2] || {};
+        
     if (intensity_data && index >= 0 && index < intensity_data.values.length) {
       intensity_data.values[index] = value;
 
@@ -144,10 +160,26 @@ BrainBrowser.SurfaceViewer.modules.color = function(viewer) {
   * ```js
   * viewer.setIntensityRange(intensity_data, 2.0, 3.0);
   * ```
+  * Note that if this method is called without an explicit **intensity\_data**
+  * argument, it will update the first available intensity dataset.
+  * ```js
+  * viewer.ssetIntensityRange(2.0, 3.0);
+  * ```
   */
-  viewer.setIntensityRange = function(intensity_data, min, max, options) {
-    options = options || {};
-    var model_data = intensity_data.model_data;
+  viewer.setIntensityRange = function() {
+    var args = Array.prototype.slice.call(arguments);
+    var intensity_data, min, max, options, model_data;
+
+    if (!BrainBrowser.utils.isNumeric(args[0])) {
+      intensity_data = args.shift();
+    } else {
+      intensity_data = viewer.model_data.getDefaultIntensityData();
+    }
+    model_data = intensity_data.model_data;
+
+    min = args[0];
+    max = args[1];
+    options = args[2] || {};
     
     intensity_data.range_min = min;
     intensity_data.range_max = max;

--- a/src/brainbrowser/surface-viewer/modules/loading.js
+++ b/src/brainbrowser/surface-viewer/modules/loading.js
@@ -32,7 +32,7 @@ BrainBrowser.SurfaceViewer.modules.loading = function(viewer) {
   var THREE = SurfaceViewer.THREE;
   var loader = BrainBrowser.loader;
 
-  var model_data;
+  var model_data_store = {};
 
   ////////////////////////////////////
   // Interface
@@ -55,7 +55,7 @@ BrainBrowser.SurfaceViewer.modules.loading = function(viewer) {
     * ```
     */
     add: function(name, data) {
-      model_data[name] = data;
+      model_data_store[name] = data;
       data.intensity_data = [];
     },
 
@@ -81,13 +81,61 @@ BrainBrowser.SurfaceViewer.modules.loading = function(viewer) {
     * ```
     */
     get: function(name) {
-      name = name || Object.keys(model_data)[0];
+      name = name || Object.keys(model_data_store)[0];
 
-      return model_data[name] || null;
+      return model_data_store[name] || null;
     },
 
+    /**
+    * @doc function
+    * @name viewer.model\_data:getDefaultIntensityData
+    * @param {string} name (Optional) Identifier for the model description to
+    * retrieve.
+    *
+    * @description
+    * Return the first loaded intensity data for the named model. If 
+    * no model name is given, will return the first available intensity
+    * data set on any loaded model. 
+    *
+    * ```js
+    * viewer.model_data.getDefaultIntensityData(model_name);
+    * ```
+    */
+    getDefaultIntensityData: function(name) {
+      var model_data;
+      var intensity_data;
+      var i, count;
+
+      if (name) {
+        model_data = this.get(name);
+        intensity_data = model_data ? model_data.intensity_data[0] : null;
+      } else {
+        model_data = Object.keys(model_data_store).map(function(name) { return model_data_store[name]});
+        
+        for (i = 0, count = model_data.length; i < count; i++) {
+          intensity_data = model_data[i].intensity_data[0];
+          if (intensity_data) {
+            break;
+          }
+        }
+      }
+
+      return intensity_data || null;
+    },
+
+    /**
+    * @doc function
+    * @name viewer.model\_data:count
+    *
+    * @description
+    * Return the number of models loaded.
+    *
+    * ```js
+    * viewer.model_data.count();
+    * ```
+    */
     count: function() {
-      return Object.keys(model_data).length;
+      return Object.keys(model_data_store).length;
     },
 
     /**
@@ -102,7 +150,7 @@ BrainBrowser.SurfaceViewer.modules.loading = function(viewer) {
     * ```
     */
     clear: function() {
-      model_data = {};
+      model_data_store = {};
     },
 
     /**
@@ -122,8 +170,8 @@ BrainBrowser.SurfaceViewer.modules.loading = function(viewer) {
     * ```
     */
     forEach: function(callback) {
-      Object.keys(model_data).forEach(function(name) {
-        callback(model_data[name], name);
+      Object.keys(model_data_store).forEach(function(name) {
+        callback(model_data_store[name], name);
       });
     }
   };


### PR DESCRIPTION
setIntensity\* methods can now be used without explicit intensity data.
model_data.getDefaultIntensityData now finds first available intensity dataset.
Closes #214.
