### PR TITLE
Surface Viewer no longer sets window.onresize

### DIFF
--- a/examples/surface-viewer-demo.js
+++ b/examples/surface-viewer-demo.js
@@ -880,6 +880,10 @@ $(function() {
       viewer.loadColorMapFromFile(this);
     });
 
+    $(window).resize(function() {
+      viewer.updateViewport();
+    });
+
     // Load first model.
     $("a.example[data-example-name=atlas]").click();
 

--- a/src/brainbrowser/surface-viewer.js
+++ b/src/brainbrowser/surface-viewer.js
@@ -289,6 +289,11 @@
         touches: BrainBrowser.utils.captureTouch(dom_element),
         updated: true,
         zoom: 1,
+        autorotate: {
+          x: false,
+          y: false,
+          z: false
+        },
         /**
         * @doc function
         * @name viewer.attributes:getAttribute

--- a/src/brainbrowser/surface-viewer/modules/rendering.js
+++ b/src/brainbrowser/surface-viewer/modules/rendering.js
@@ -58,27 +58,36 @@ BrainBrowser.SurfaceViewer.modules.rendering = function(viewer) {
   viewer.render = function() {
     var dom_element = viewer.dom_element;
     renderer.setClearColor(0x000000);
-    renderer.setSize(dom_element.offsetWidth, dom_element.offsetHeight);
     dom_element.appendChild(renderer.domElement);
     
     camera.position.z = default_camera_distance;
     
     light.position.set(0, 0, default_camera_distance);
     scene.add(light);
-    
-    viewer.autorotate = {};
-    
-    window.onresize = function() {
-      effect.setSize(dom_element.offsetWidth, dom_element.offsetHeight);
-      camera.aspect = dom_element.offsetWidth / dom_element.offsetHeight;
-      camera.updateProjectionMatrix();
-
-      viewer.updated = true;
-    };
-    
-    window.onresize();
+        
+    viewer.updateViewport();
     
     renderFrame();
+  };
+
+  /**
+  * @doc function
+  * @name viewer.rendering:updateViewport
+  * @description
+  * Update the viewport size and aspect ratio to fit
+  * the current size of the viewer DOM element.
+  * ```js
+  * viewer.updateViewport();
+  * ```
+  */
+  viewer.updateViewport = function() {
+    var dom_element = viewer.dom_element;
+
+    effect.setSize(dom_element.offsetWidth, dom_element.offsetHeight);
+    camera.aspect = dom_element.offsetWidth / dom_element.offsetHeight;
+    camera.updateProjectionMatrix();
+
+    viewer.updated = true;
   };
 
   /**


### PR DESCRIPTION
New method viewer.updateViewport() to set viewer size and fix aspect ratio.
Closes #223.
