### PR TITLE
Fix orientation for lateral/medial views so that they do something reasonable for non-split models.

### DIFF
--- a/src/brainbrowser/surface-viewer/modules/views.js
+++ b/src/brainbrowser/surface-viewer/modules/views.js
@@ -44,6 +44,11 @@ BrainBrowser.SurfaceViewer.modules.views = function(viewer) {
         model.getObjectByName("right").rotation.z += Math.PI / 2;
         model.rotation.x -= Math.PI / 2;
       }
+      else {
+        model.rotation.x += Math.PI / 2;
+        model.rotation.y += Math.PI;
+        model.rotation.z += Math.PI / 2;
+      }
     },
 
     lateralView: function(model_data) {
@@ -60,6 +65,11 @@ BrainBrowser.SurfaceViewer.modules.views = function(viewer) {
         right_child.rotation.z += Math.PI / 2;
         model.rotation.x += Math.PI / 2;
         model.rotation.y += Math.PI;
+      }
+      else {
+        model.rotation.x += Math.PI / 2;
+        model.rotation.y += Math.PI;
+        model.rotation.z -= Math.PI / 2;
       }
     },
 


### PR DESCRIPTION
The existing code simply ignores requests for "Medial" or "Lateral" view if the model is not split. It seems reasonable to do something for non-split images, in this case it should give a "right" view for medial, and a "left" view for lateral.

Separately we might want to discuss the utility of the split/single view paradigm.