### PR TITLE
Fix registration in overlay

### DIFF
--- a/src/brainbrowser/volume-viewer/volume-loaders/minc.js
+++ b/src/brainbrowser/volume-viewer/volume-loaders/minc.js
@@ -27,12 +27,12 @@
 
 (function() {
   "use strict";
-     
+
   var VolumeViewer = BrainBrowser.VolumeViewer;
 
   VolumeViewer.volume_loaders.minc = function(description, callback) {
     var error_message;
-    
+
     if (description.header_url && description.raw_data_url) {
       BrainBrowser.loader.loadFromURL(description.header_url, function(header_text) {
         parseHeader(header_text, function(header) {
@@ -57,14 +57,14 @@
       BrainBrowser.events.triggerEvent("error", { message: error_message });
       throw new Error(error_message);
     }
-    
+
   };
 
   /*
    * Create a volume object given a header and some byte data that
    * represents the voxels. Format-specific functions have to be
-   * used to create the header and byte_data, but this function 
-   * combines the information into the generic data structure used 
+   * used to create the header and byte_data, but this function
+   * combines the information into the generic data structure used
    * elsewhere in the volume viewer.
    */
   VolumeViewer.createVolume = function(header, byte_data) {
@@ -88,10 +88,10 @@
         }
 
         time = time || 0;
-        
+
         cached_slices[axis] = cached_slices[axis] || [];
         cached_slices[axis][time] =  cached_slices[axis][time] || [];
-        
+
         if(cached_slices[axis][time][slice_num] !== undefined) {
           return cached_slices[axis][time][slice_num];
         }
@@ -121,7 +121,7 @@
         var x, y, z;
 
         // Linear offsets into volume considering an
-        // increasing number of axes: (t) time, 
+        // increasing number of axes: (t) time,
         // (z) z-axis, (y) y-axis, (x) x-axis.
         var tz_offset, tzy_offset, tzyx_offset;
 
@@ -158,8 +158,45 @@
         };
 
         cached_slices[axis][time][slice_num] = slice;
-        
+
         return slice;
+      },
+
+      // Calculate the world to voxel transform and save it, so we
+      // can access it efficiently. The transform is:
+      // cxx / stepx | cxy / stepx | cxz / stepx | (-o.x * cxx - o.y * cxy - o.z * cxz) / stepx
+      // cyx / stepy | cyy / stepy | cyz / stepy | (-o.x * cyx - o.y * cyy - o.z * cyz) / stepy
+      // czx / stepz | czy / stepz | czz / stepz | (-o.x * czx - o.y * czy - o.z * czz) / stepz
+      // 0           | 0           | 0           | 1
+
+      // Origin equation taken from (http://www.bic.mni.mcgill.ca/software/minc/minc2_format/node4.html)
+
+      saveOriginAndTransform: function(header) {
+        var startx = header.xspace.start;
+        var starty = header.yspace.start;
+        var startz = header.zspace.start;
+        var cx = header.xspace.direction_cosines;
+        var cy = header.yspace.direction_cosines;
+        var cz = header.zspace.direction_cosines;
+        var stepx = header.xspace.step;
+        var stepy = header.yspace.step;
+        var stepz = header.zspace.step;
+        header.voxel_origin = {
+          x: startx * cx[0] + starty * cy[0] + startz * cz[0],
+          y: startx * cx[1] + starty * cy[1] + startz * cz[1],
+          z: startx * cx[2] + starty * cy[2] + startz * cz[2]
+        };
+        var o = header.voxel_origin;
+
+        var tx = (-o.x * cx[0] - o.y * cx[1] - o.z * cx[2]) / stepx;
+        var ty = (-o.x * cy[0] - o.y * cy[1] - o.z * cy[2]) / stepy;
+        var tz = (-o.x * cz[0] - o.y * cz[1] - o.z * cz[2]) / stepz;
+
+        header.w2v = [
+          [cx[0] / stepx, cx[1] / stepx, cx[2] / stepx, tx],
+          [cy[0] / stepy, cy[1] / stepy, cy[2] / stepy, ty],
+          [cz[0] / stepz, cz[1] / stepz, cz[2] / stepz, tz]
+        ];
       },
 
       getSliceImage: function(slice, zoom, contrast, brightness) {
@@ -219,7 +256,7 @@
 
         return slice.data[(slice.height_space.space_length - y - 1) * slice.width + x];
       },
-      
+
       getVoxelCoords: function() {
         var header = volume.header;
         var position = {
@@ -234,24 +271,24 @@
           k: position[header.order[2]],
         };
       },
-      
+
       setVoxelCoords: function(i, j, k) {
         var header = volume.header;
         var ispace = header.order[0];
         var jspace = header.order[1];
         var kspace = header.order[2];
-        
+
         volume.position[ispace] = header[ispace].step > 0 ? i : header[ispace].space_length - i;
         volume.position[jspace] = header[jspace].step > 0 ? j : header[jspace].space_length - j;
         volume.position[kspace] = header[kspace].step > 0 ? k : header[kspace].space_length - k;
       },
-      
+
       getWorldCoords: function() {
         var voxel = volume.getVoxelCoords();
 
         return volume.voxelToWorld(voxel.i, voxel.j, voxel.k);
       },
-      
+
       setWorldCoords: function(x, y, z) {
         var voxel = volume.worldToVoxel(x, y, z);
 
@@ -293,36 +330,19 @@
         };
       },
 
-      // World to voxel matrix applied here is:
-      // cxx / stepx | cxy / stepx | cxz / stepx | (-o.x * cxx - o.y * cxy - o.z * cxz) / stepx
-      // cyx / stepy | cyy / stepy | cyz / stepy | (-o.x * cyx - o.y * cyy - o.z * cyz) / stepy
-      // czx / stepz | czy / stepz | czz / stepz | (-o.x * czx - o.y * czy - o.z * czz) / stepz
-      // 0           | 0           | 0           | 1
-      //
       // Inverse of the voxel to world matrix.
       worldToVoxel: function(x, y, z) {
-        var header = volume.header;
-        var cx = header.xspace.direction_cosines;
-        var cy = header.yspace.direction_cosines;
-        var cz = header.zspace.direction_cosines;
-        var stepx = header.xspace.step;
-        var stepy = header.yspace.step;
-        var stepz = header.zspace.step;
-        var o = header.voxel_origin;
-        var tx = (-o.x * cx[0] - o.y * cx[1] - o.z * cx[2]) / stepx;
-        var ty = (-o.x * cy[0] - o.y * cy[1] - o.z * cy[2]) / stepy;
-        var tz = (-o.x * cz[0] - o.y * cz[1] - o.z * cz[2]) / stepz;
-
+        var xfm = header.w2v;   // Get the world-to-voxel transform.
         var result = {
-          x: Math.round(x * cx[0] / stepx + y * cx[1] / stepx + z * cx[2] / stepx + tx),
-          y: Math.round(x * cy[0] / stepy + y * cy[1] / stepy + z * cy[2] / stepy + ty),
-          z: Math.round(x * cz[0] / stepz + y * cz[1] / stepz + z * cz[2] / stepz + tz)
+          vx: x * xfm[0][0] + y * xfm[0][1] + z * xfm[0][2] + xfm[0][3],
+          vy: x * xfm[1][0] + y * xfm[1][1] + z * xfm[1][2] + xfm[1][3],
+          vz: x * xfm[2][0] + y * xfm[2][1] + z * xfm[2][2] + xfm[2][3]
         };
 
         var ordered = {};
-        ordered[header.order[0]] = result.x;
-        ordered[header.order[1]] = result.y;
-        ordered[header.order[2]] = result.z;
+        ordered[header.order[0]] = Math.round(result.vx);
+        ordered[header.order[1]] = Math.round(result.vy);
+        ordered[header.order[2]] = Math.round(result.vz);
 
         return {
           i: ordered.xspace,
@@ -336,7 +356,8 @@
 
   function createMincVolume(header, raw_data, callback){
     var volume = VolumeViewer.createVolume(header, new Uint8Array(raw_data));
-    
+
+    volume.saveOriginAndTransform(header);
     if (BrainBrowser.utils.isFunction(callback)) {
       callback(volume);
     }
@@ -357,7 +378,7 @@
       throw new Error(error_message);
     }
 
-    
+
     if(header.order.length === 4) {
       header.order = header.order.slice(1);
     }
@@ -365,7 +386,7 @@
     header.xspace.name = "xspace";
     header.yspace.name = "yspace";
     header.zspace.name = "zspace";
-    
+
     header.xspace.space_length = parseFloat(header.xspace.space_length);
     header.yspace.space_length = parseFloat(header.yspace.space_length);
     header.zspace.space_length = parseFloat(header.zspace.space_length);
@@ -385,13 +406,6 @@
     cx = header.xspace.direction_cosines = header.xspace.direction_cosines.map(parseFloat);
     cy = header.yspace.direction_cosines = header.yspace.direction_cosines.map(parseFloat);
     cz = header.zspace.direction_cosines = header.zspace.direction_cosines.map(parseFloat);
-
-    // Origin equation taken from (http://www.bic.mni.mcgill.ca/software/minc/minc2_format/node4.html)
-    header.voxel_origin = {
-      x: startx * cx[0] + starty * cy[0] + startz * cz[0],
-      y: startx * cx[1] + starty * cy[1] + startz * cz[1],
-      z: startx * cx[2] + starty * cy[2] + startz * cz[2]
-    };
 
     header.xspace.width_space  = header.yspace;
     header.xspace.width        = header.yspace.space_length;
@@ -425,5 +439,5 @@
     }
 
   }
-   
+
 }());

--- a/src/brainbrowser/volume-viewer/volume-loaders/nifti1.js
+++ b/src/brainbrowser/volume-viewer/volume-loaders/nifti1.js
@@ -197,9 +197,9 @@
 
     // Calculate the determinant of a 3x3 matrix.
     function determinant(c0, c1, c2) {
-        return (c0[0] * (c1[1] * c2[2] - c1[2] * c2[1]) +
-                c0[1] * (c1[2] * c2[0] - c1[0] * c2[2]) +
-                c0[2] * (c1[0] * c2[2] - c1[1] * c2[0]));
+      return (c0[0] * (c1[1] * c2[2] - c1[2] * c2[1]) +
+              c0[1] * (c1[2] * c2[0] - c1[0] * c2[2]) +
+              c0[2] * (c1[0] * c2[2] - c1[1] * c2[0]));
     }
 
     // Now that we have the transform, need to convert it to MINC-like

--- a/src/brainbrowser/volume-viewer/volume-loaders/nifti1.js
+++ b/src/brainbrowser/volume-viewer/volume-loaders/nifti1.js
@@ -24,14 +24,14 @@
 * Author: Nicolas Kassis
 * Author: Tarek Sherif <tsherif@gmail.com> (http://tareksherif.ca/)
 * Author: Robert D. Vincent <robert.d.vincent@mcgill.ca>
-* 
-* Loads NIfTI-1 files for volume viewer. For details on the NIfTI-1 format, 
+*
+* Loads NIfTI-1 files for volume viewer. For details on the NIfTI-1 format,
 * see: http://nifti.nimh.nih.gov/nifti-1/documentation/nifti1fields
 */
 
 (function() {
   "use strict";
-     
+
   var VolumeViewer = BrainBrowser.VolumeViewer;
 
   VolumeViewer.volume_loaders.nifti1 = function(description, callback) {
@@ -42,7 +42,7 @@
           createNifti1Volume(header, nii_data, callback);
         });
       }, {result_type: "arraybuffer" });
-                                        
+
     } else if (description.nii_file) {
       BrainBrowser.loader.loadFromFile(description.nii_file, function(nii_data) {
         parseNifti1Header(nii_data, function(header) {
@@ -56,7 +56,7 @@
       BrainBrowser.events.triggerEvent("error", { message: error_message });
       throw new Error(error_message);
     }
-    
+
   };
 
   function parseNifti1Header(raw_data, callback) {
@@ -138,14 +138,14 @@
       header.order = ["time", "zspace", "yspace", "xspace"];
     }
 
-    /* Record the number of bytes per voxel, and note whether we need 
+    /* Record the number of bytes per voxel, and note whether we need
      * to swap bytes in the voxel data.
      */
     header.bytes_per_voxel = bitpix / 8;
     header.must_swap_data = !littleEndian && header.bytes_per_voxel > 1;
 
     if (sform_code > 0) {
-      /* The "Sform", if present, defines an affine transform which is 
+      /* The "Sform", if present, defines an affine transform which is
        * generally assumed to correspond to some standard coordinate
        * space (e.g. Talairach).
        */
@@ -195,7 +195,7 @@
       return Math.sqrt(dotprod);
     }
 
-    // Now that we have the transform, need to convert it to MINC-like 
+    // Now that we have the transform, need to convert it to MINC-like
     // steps and direction_cosines.
 
     var xmag = magnitude(transform[0]);
@@ -211,7 +211,7 @@
       y_dir_cosines[i] = transform[1][i] / ystep;
       z_dir_cosines[i] = transform[2][i] / zstep;
     }
-        
+
     header.xspace.step = xstep;
     header.yspace.step = ystep;
     header.zspace.step = zstep;
@@ -255,7 +255,7 @@
     var d = qd;
     var a, xd, yd, zd;
 
-    // compute a parameter from b,c,d 
+    // compute a parameter from b,c,d
 
     a = 1.0 - (b * b + c * c + d * d);
     if ( a < 1.e-7 ) {           // special case
@@ -268,7 +268,7 @@
       a = Math.sqrt(a);          // angle = 2*arccos(a)
     }
 
-    // load rotation matrix, including scaling factors for voxel sizes 
+    // load rotation matrix, including scaling factors for voxel sizes
 
     xd = (dx > 0.0) ? dx : 1.0;  // make sure are positive
     yd = (dy > 0.0) ? dy : 1.0;
@@ -299,7 +299,8 @@
   function createNifti1Volume(header, raw_data, callback) {
     var volume = VolumeViewer.createVolume(header,
                                            createNifti1Data(header, raw_data));
-    
+
+    volume.saveOriginAndTransform(header);
     if (BrainBrowser.utils.isFunction(callback)) {
       callback(volume);
     }
@@ -420,5 +421,5 @@
 
     return byte_data;
   }
-   
+
 }());

--- a/src/brainbrowser/volume-viewer/volume-loaders/nifti1.js
+++ b/src/brainbrowser/volume-viewer/volume-loaders/nifti1.js
@@ -229,18 +229,18 @@
                   transform[2][3]
                  ];
 
-    // In practice, I believe that the determinant of the direction
+    // (bert): I believe that the determinant of the direction
     // cosines should always work out to 1, so the calculation of
     // this value should not be needed. But I have no idea if NIfTI
     // enforces this when sform transforms are written.
-    var D = determinant(x_dir_cosines, y_dir_cosines, z_dir_cosines);
+    var denom = determinant(x_dir_cosines, y_dir_cosines, z_dir_cosines);
     var xstart = determinant(starts, y_dir_cosines, z_dir_cosines);
     var ystart = determinant(x_dir_cosines, starts, z_dir_cosines);
     var zstart = determinant(x_dir_cosines, y_dir_cosines, starts);
 
-    header.xspace.start = xstart / D;
-    header.yspace.start = ystart / D;
-    header.zspace.start = zstart / D;
+    header.xspace.start = xstart / denom;
+    header.yspace.start = ystart / denom;
+    header.zspace.start = zstart / denom;
 
     header.xspace.direction_cosines = x_dir_cosines;
     header.yspace.direction_cosines = y_dir_cosines;

--- a/src/brainbrowser/volume-viewer/volume-loaders/overlay.js
+++ b/src/brainbrowser/volume-viewer/volume-loaders/overlay.js
@@ -106,7 +106,7 @@
         // Calculate the maximum width and height for the set of
         // volumes. We need this to set the overall field of view.
         //
-        slices.forEach(function(slice, i) {
+        slices.forEach(function(slice) {
           var xstep = slice.width_space.step;
           var ystep = slice.height_space.step;
 


### PR DESCRIPTION
This pull request contains three commits. 

The first commit is an attempt to properly align two (or more) volumes when in an overlay, by converting from a standardized world coordinate space into the voxel coordinate space of each volume. I also fixed a minor issue in the calculation of the merged intensities.

The second commit is a small improvement to the performance of the "worldToVoxel()" function, which is useful because the previous commit makes extensive use of that function.

The final commit patches nifti1.js to create the same transform used by the previous commit, so that NIfTI-1 and MINC files should register properly.