### PR TITLE
Fix #194 and #15. Use world coordinates for synchronization.

### DIFF
--- a/examples/volume-viewer-demo.js
+++ b/examples/volume-viewer-demo.js
@@ -272,7 +272,14 @@ $(function() {
         }
 
         // Set coordinates and redraw.
-        viewer.volumes[vol_id].setWorldCoords(x, y, z);
+        if (viewer.synced) {
+          viewer.volumes.forEach(function(volume) {
+            volume.setWorldCoords(x, y, z);
+          });
+        }
+        else {
+          viewer.volumes[vol_id].setWorldCoords(x, y, z);
+        }
 
         viewer.redrawVolumes();
       });
@@ -298,6 +305,15 @@ $(function() {
 
         // Set coordinates and redraw.
         viewer.volumes[vol_id].setVoxelCoords(i, j, k);
+        if (viewer.synced) {
+          var synced_volume = viewer.volumes[vol_id];
+          var wc = synced_volume.getWorldCoords();
+          viewer.volumes.forEach(function(volume) {
+            if (synced_volume !== volume) {
+              volume.setWorldCoords(wc.x, wc.y, wc.z);
+            }
+          });
+        }
 
         viewer.redrawVolumes();
       });

--- a/src/brainbrowser/volume-viewer.js
+++ b/src/brainbrowser/volume-viewer.js
@@ -414,7 +414,6 @@
 
         var key = event.which;
         var space_name, time;
-        var cursor;
         
         var keys = {
           // CTRL
@@ -472,21 +471,7 @@
           });
 
           if (viewer.synced){
-            cursor = panel.getCursorPosition();
-
-            viewer.volumes.forEach(function(synced_volume) {
-              var synced_panel;
-              
-              if (synced_volume !== volume) {
-                synced_panel = synced_volume.display.getPanel(axis_name);
-                synced_panel.updateVolumePosition(cursor.x, cursor.y);
-                synced_volume.display.forEach(function(panel) {
-                  if (panel !== synced_panel) {
-                    panel.updateSlice();
-                  }
-                });
-              }
-            });
+            viewer.syncPosition(panel, volume, axis_name);
           }
           
           return false;

--- a/src/brainbrowser/volume-viewer/modules/loading.js
+++ b/src/brainbrowser/volume-viewer/modules/loading.js
@@ -344,6 +344,22 @@ BrainBrowser.VolumeViewer.modules.loading = function(viewer) {
     default_panel_height = height;
   };
 
+  viewer.syncPosition = function(panel, volume, axis_name) {
+    var wc = volume.getWorldCoords();
+    viewer.volumes.forEach(function(synced_volume) {
+      if (synced_volume !== volume) {
+        var synced_panel = synced_volume.display.getPanel(axis_name);
+        synced_panel.volume.setWorldCoords(wc.x, wc.y, wc.z);
+        synced_panel.updated = true;
+        synced_volume.display.forEach(function(panel) {
+          if (panel !== synced_panel) {
+            panel.updateSlice();
+          }
+        });
+      }
+    });
+  };
+
   ///////////////////////////
   // Private Functions
   ///////////////////////////
@@ -533,22 +549,9 @@ BrainBrowser.VolumeViewer.modules.loading = function(viewer) {
             });
 
             if (viewer.synced){
-              viewer.volumes.forEach(function(synced_volume, synced_vol_id) {
-                var synced_panel;
-                
-                if (synced_vol_id !== vol_id) {
-                  synced_panel = synced_volume.display.getPanel(axis_name);
-                  synced_panel.updateVolumePosition(pointer.x, pointer.y);
-                  synced_volume.display.forEach(function(panel) {
-                    if (panel !== synced_panel) {
-                      panel.updateSlice();
-                    }
-                  });
-                }
-              });
+              viewer.syncPosition(panel, volume, axis_name);
             }
           }
-
           panel.updated = true;
         }
 
@@ -576,19 +579,7 @@ BrainBrowser.VolumeViewer.modules.loading = function(viewer) {
             });
 
             if (viewer.synced){
-              viewer.volumes.forEach(function(synced_volume, synced_vol_id) {
-                var synced_panel;
-                
-                if (synced_vol_id !== vol_id) {
-                  synced_panel = synced_volume.display.getPanel(axis_name);
-                  synced_panel.updateVolumePosition(pointer.x, pointer.y);
-                  synced_volume.display.forEach(function(panel) {
-                    if (panel !== synced_panel) {
-                      panel.updateSlice();
-                    }
-                  });
-                }
-              });
+              viewer.syncPosition(panel, volume, axis_name);
             }
           }
 

--- a/src/brainbrowser/volume-viewer/volume-loaders/nifti1.js
+++ b/src/brainbrowser/volume-viewer/volume-loaders/nifti1.js
@@ -326,7 +326,7 @@
   function createNifti1Volume(header, raw_data, callback) {
     var volume = VolumeViewer.createVolume(header,
                                            createNifti1Data(header, raw_data));
-
+    volume.type = "nifti";
     volume.saveOriginAndTransform(header);
     if (BrainBrowser.utils.isFunction(callback)) {
       callback(volume);
@@ -411,31 +411,6 @@
     if(header.order.length === 4) {
       header.order = header.order.slice(1);
     }
-
-    header.xspace.name = "xspace";
-    header.yspace.name = "yspace";
-    header.zspace.name = "zspace";
-
-    header.voxel_origin = {
-      x: header.xspace.start,
-      y: header.yspace.start,
-      z: header.zspace.start
-    };
-
-    header.xspace.width_space  = header.yspace;
-    header.xspace.width        = header.yspace.space_length;
-    header.xspace.height_space = header.zspace;
-    header.xspace.height       = header.zspace.space_length;
-
-    header.yspace.width_space  = header.xspace;
-    header.yspace.width        = header.xspace.space_length;
-    header.yspace.height_space = header.zspace;
-    header.yspace.height       = header.zspace.space_length;
-
-    header.zspace.width_space  = header.xspace;
-    header.zspace.width        = header.xspace.space_length;
-    header.zspace.height_space = header.yspace;
-    header.zspace.height       = header.yspace.space_length;
 
     // Incrementation offsets for each dimension of the volume.
     header[header.order[0]].offset = header[header.order[1]].space_length * header[header.order[2]].space_length;

--- a/src/brainbrowser/volume-viewer/volume-loaders/overlay.js
+++ b/src/brainbrowser/volume-viewer/volume-loaders/overlay.js
@@ -26,7 +26,9 @@
 */
 
 /**
- * Represents a blended volume
+ * Represents a blended volume. It does so at least in part by
+ * defining its own "virtual" world space and superimposing the
+ * other volumes onto this space.
  */
 
 (function() {
@@ -39,213 +41,213 @@
     options = options || {};
     var volumes = options.volumes || [];
 
-    var overlay_volume = {
-      type: "overlay",
-      position: {},
-      header: volumes[0] ? volumes[0].header : {},
-      intensity_min: 0,
-      intensity_max: 255,
-      volumes: [],
-      blend_ratios: [],
-      slice: function(axis, slice_num, time) {
-        slice_num = slice_num === undefined ? this.position[axis] : slice_num;
-        time = time === undefined ? this.current_time : time;
+    /*
+     * Initialize the header to a fairly generic setting. This allows
+     * us to fully define "world coordinates" in this volume. This is
+     * important if we're going to synchronize all slices on world
+     * coordinates.
+     */
+    var header = {};
+    var SIZE = 256;
+    var order = ["xspace", "yspace", "zspace"];
+    header.order = order;
 
-        var overlay_volume = this;
-        var slices = [];
+    for (var i = 0; i < order.length; i++) {
+      header[order[i]] = {};
+      header[order[i]].step = 1;
+      header[order[i]].start = -SIZE / 2;
+      header[order[i]].direction_cosines = [0, 0, 0];
+      header[order[i]].direction_cosines[i] = 1;
+      header[order[i]].space_length = SIZE;
+    }
+    /* Use this header to create the volume object for the
+     * overlay. This will set the transform and populate
+     * essential member functions.
+     */
+    var overlay_volume = VolumeViewer.createVolume(header, []);
 
-        overlay_volume.volumes.forEach(function(volume) {
-          /*
-           * We need to correct the slice_num for images with different
-           * numbers of points along an axis. Otherwise we won't form
-           * the composite image correctly.
-           * TODO: This is only a partial fix, and should be improved.
-           */
-          var factor = volume.header[axis].step / volumes[0].header[axis].step;
-          var corrected_slice_num = Math.round(slice_num / factor);
-          var slice = volume.slice(axis, corrected_slice_num, time);
-          slices.push(slice);
-        });
+    overlay_volume.type = "overlay"; // Set the type.
 
-        return {
-          height_space: slices[0].height_space,
-          width_space: slices[0].width_space,
-          slices: slices
-        };
-      },
+    /* Create the three special fields the overlay contains - the base
+     * size of its voxel dimensions, the list of overlaid volumes and
+     * the blend ratios to apply to those volumes.
+     */
+    overlay_volume.size = SIZE;
+    overlay_volume.volumes = [];
+    overlay_volume.blend_ratios = [];
 
-      // Calculates the axis coordinate in world space.
-      //
-      getSliceCoordinate: function(header, axis_name) {
-        var vc = {
-          i: overlay_volume.position[header.order[0]],
-          j: overlay_volume.position[header.order[1]],
-          k: overlay_volume.position[header.order[2]]
-        };
-        var wc = overlay_volume.volumes[0].voxelToWorld(vc.i, vc.j, vc.k);
+    overlay_volume.saveOriginAndTransform(header);
 
-        var result = 0;
-        if (axis_name === "xspace")
-          result = wc.x;
-        else if (axis_name === "yspace")
-          result = wc.y;
-        else
-          result = wc.z;
-        return result;
-      },
+    /* Override the default slice function. This one does not really
+     * return the data at all, since the overlay contains no data of
+     * its own. It just gets references to the slices in the overlaid
+     * volumes and returns a more-or-less valid slice object.
+     */
+    overlay_volume.slice = function(axis, slice_num, time) {
+      slice_num = slice_num === undefined ? this.position[axis] : slice_num;
+      time = time === undefined ? this.current_time : time;
 
-      // Get the slice image, at the requested zoom level, contrast
-      // and brightness. Zoom values of less than one imply a smaller
-      // image (therefore a larger field of view)
-      getSliceImage: function(slice, zoom, contrast, brightness) {
-        zoom = zoom || 1;
+      var slices = [];
 
-        var slices = slice.slices;
-        var images = [];
-        var max_width = 0;
-        var max_height = 0;
-        var overlay_volume = this;
+      this.volumes.forEach(function(volume) {
+        /*
+         * We need to correct the slice_num for images with different
+         * numbers of points along an axis. Otherwise we won't form
+         * the composite image correctly.
+         * TODO: This is only a partial fix, and should be improved.
+         */
+        var factor = volume.header[axis].step / volumes[0].header[axis].step;
+        var corrected_slice_num = Math.round(slice_num / factor);
+        var slice = volume.slice(axis, corrected_slice_num, time);
+        slices.push(slice);
+      });
 
-        // Calculate the maximum width and height for the set of
-        // volumes. We need this to set the overall field of view.
-        // TODO: Fix this to get a true field of view.
-        slices.forEach(function(slice) {
-          var xstep = slice.width_space.step;
-          var ystep = slice.height_space.step;
+      return {
+        height_space: header[axis].height_space,
+        width_space: header[axis].width_space,
+        slices: slices
+      };
+    };
 
-          var target_width = Math.abs(Math.floor(slice.width * xstep * zoom));
-          var target_height = Math.abs(Math.floor(slice.height * ystep * zoom));
+    // Get the slice image, at the requested zoom level, contrast
+    // and brightness. Zoom values of less than one imply a smaller
+    // image (therefore a larger field of view)
+    overlay_volume.getSliceImage = function(slice, zoom, contrast, brightness) {
+      zoom = zoom || 1;
 
-          max_width = Math.max(max_width, target_width);
-          max_height = Math.max(max_height, target_height);
-        });
+      var slices = slice.slices;
+      var images = [];
+      var max_width = Math.round(this.size * zoom);
+      var max_height = max_width;
 
-        slices.forEach(function(slice, i) {
-          var volume = overlay_volume.volumes[i];
-          var color_map = volume.color_map;
-          var intensity_min = volume.intensity_min;
-          var intensity_max = volume.intensity_max;
-          var error_message;
+      slices.forEach(function(slice, i) {
+        var volume = overlay_volume.volumes[i];
+        var color_map = volume.color_map;
+        var intensity_min = volume.intensity_min;
+        var intensity_max = volume.intensity_max;
+        var error_message;
 
-          if (!color_map) {
-            error_message = "No color map set for this volume. Cannot render slice.";
-            overlay_volume.triggerEvent("error", { message: error_message });
-            throw new Error(error_message);
-          }
+        if (!color_map) {
+          error_message = "No color map set for this volume. Cannot render slice.";
+          this.triggerEvent("error", { message: error_message });
+          throw new Error(error_message);
+        }
 
-          var target_image = image_creation_context.createImageData(max_width, max_height);
+        var target_image = image_creation_context.createImageData(max_width, max_height);
 
-          var min_col = -max_width / 2;
-          var max_col = max_width / 2;
-          var min_row = -max_height / 2;
-          var max_row = max_height / 2;
+        var min_col = -max_width / 2;
+        var max_col = max_width / 2;
+        var min_row = -max_height / 2;
+        var max_row = max_height / 2;
 
-          var header = volume.header;
+        var header = volume.header;
 
-          var time_offset = header.time ? volume.current_time * header.time.offset : 0;
+        var time_offset = header.time ? volume.current_time * header.time.offset : 0;
 
-          var axis_space = header[slice.axis];
-          var width_space = axis_space.width_space;
-          var height_space = axis_space.height_space;
+        var axis_space = header[slice.axis];
+        var width_space = axis_space.width_space;
+        var height_space = axis_space.height_space;
 
-          var i_offset = header[header.order[0]].offset;
-          var j_offset = header[header.order[1]].offset;
-          var k_offset = header[header.order[2]].offset;
+        var i_offset = header[header.order[0]].offset;
+        var j_offset = header[header.order[1]].offset;
+        var k_offset = header[header.order[2]].offset;
 
-          var sizes = [
-            header[header.order[0]].space_length,
-            header[header.order[1]].space_length,
-            header[header.order[2]].space_length
-          ];
+        var sizes = [
+          header[header.order[0]].space_length,
+          header[header.order[1]].space_length,
+          header[header.order[2]].space_length
+        ];
 
-          var slice_data = new Uint8Array(max_width * max_height);
-          var data_index = 0;
+        var data_length = max_width * max_height;
+        var slice_data = new Uint8Array(data_length);
+        var data_index = 0;
 
-          // We need to calculate the slice coordinate in world
-          // space in order to properly align the volumes.
-          //
-          var c_axis = overlay_volume.getSliceCoordinate(header,
-                                                         axis_space.name);
+        // We need to calculate the slice coordinate in world
+        // space in order to properly align the volumes.
+        //
+        var c_axis = getSliceCoordinate(overlay_volume, axis_space.name);
 
-          for (var c_row = max_row; c_row >= min_row; c_row--) {
-            for (var c_col = min_col; c_col < max_col; c_col++) {
-              var wc = {};
-              wc[slice.axis] = c_axis;
-              wc[width_space.name] = c_col / zoom;
-              wc[height_space.name] = c_row / zoom;
-              var vc = volume.worldToVoxel(wc.xspace, wc.yspace, wc.zspace);
-              if (vc.i < 0 || vc.i >= sizes[0] ||
-                  vc.j < 0 || vc.j >= sizes[1] ||
-                  vc.k < 0 || vc.k >= sizes[2]) {
-                slice_data[data_index] = 0;
-              }
-              else {
-                var volume_index = (time_offset +
-                                    vc.i * i_offset +
-                                    vc.j * j_offset +
-                                    vc.k * k_offset);
+        for (var c_row = max_row-1; c_row >= min_row; c_row--) {
+          for (var c_col = min_col; c_col < max_col; c_col++) {
+            var wc = {};
+            wc[slice.axis] = c_axis;
+            wc[width_space.name] = c_col / zoom;
+            wc[height_space.name] = c_row / zoom;
+            var vc = volume.worldToVoxel(wc.xspace, wc.yspace, wc.zspace);
+            if (vc.i < 0 || vc.i >= sizes[0] ||
+                vc.j < 0 || vc.j >= sizes[1] ||
+                vc.k < 0 || vc.k >= sizes[2]) {
+              slice_data[data_index] = 0;
+            }
+            else {
+              var volume_index = (time_offset +
+                                  vc.i * i_offset +
+                                  vc.j * j_offset +
+                                  vc.k * k_offset);
+              if (data_index < data_length)
                 slice_data[data_index] = volume.data[volume_index];
-              }
-              data_index++;
             }
+            data_index++;
           }
+        }
 
-          color_map.mapColors(slice_data, {
-            min: intensity_min,
-            max: intensity_max,
-            contrast: contrast,
-            brightness: brightness,
-            destination: target_image.data
-          });
-
-          images.push(target_image);
+        color_map.mapColors(slice_data, {
+          min: intensity_min,
+          max: intensity_max,
+          contrast: contrast,
+          brightness: brightness,
+          destination: target_image.data
         });
 
-        return blendImages(
-          images,
-          overlay_volume.blend_ratios,
-          image_creation_context.createImageData(max_width, max_height)
-        );
-      },
+        images.push(target_image);
+      });
 
-      getIntensityValue: function(x, y, z, time) {
-        x = x === undefined ? this.position.xspace : x;
-        y = y === undefined ? this.position.yspace : y;
-        z = z === undefined ? this.position.zspace : z;
-        time = time === undefined ? this.current_time : time;
+      return blendImages(
+        images,
+        overlay_volume.blend_ratios,
+        image_creation_context.createImageData(max_width, max_height)
+      );
+    };
 
-        var overlay_volume = this;
-        var values = [];
+    /* Override the getIntensityValue function. The intensity of
+     * the overlaid image is defined as the mean of the individual
+     * volume intensities, weighted by the blend values.
+     */
+    overlay_volume.getIntensityValue = function(x, y, z, time) {
+      x = x === undefined ? this.position.xspace : x;
+      y = y === undefined ? this.position.yspace : y;
+      z = z === undefined ? this.position.zspace : z;
+      time = time === undefined ? this.current_time : time;
+      var values = [];
 
-        overlay_volume.volumes.forEach(function(volume) {
-          var header = volume.header;
+      this.volumes.forEach(function(volume) {
+        var header = volume.header;
 
-          if (x < 0 || x > header.xspace.space_length ||
-            y < 0 || y > header.yspace.space_length ||
-            z < 0 || z > header.zspace.space_length) {
-            values.push(0);
+        if (x < 0 || x > header.xspace.space_length ||
+          y < 0 || y > header.yspace.space_length ||
+          z < 0 || z > header.zspace.space_length) {
+          values.push(0);
+        }
+        else {
+          var slice = volume.slice("zspace", z, time);
+          var data = slice.data;
+          var slice_x, slice_y;
+
+          if (slice.width_space.name === "xspace") {
+            slice_x = x;
+            slice_y = y;
+          } else {
+            slice_x = y;
+            slice_y = z;
           }
-          else {
-            var slice = volume.slice("zspace", z, time);
-            var data = slice.data;
-            var slice_x, slice_y;
 
-            if (slice.width_space.name === "xspace") {
-              slice_x = x;
-              slice_y = y;
-            } else {
-              slice_x = y;
-              slice_y = z;
-            }
+          values.push(data[(slice.height_space.space_length - slice_y - 1) * slice.width + slice_x]);
+        }
+      });
 
-            values.push(data[(slice.height_space.space_length - slice_y - 1) * slice.width + slice_x]);
-          }
-        });
-
-        return values.reduce(function(intensity, current_value, i) {
-          return intensity + current_value * overlay_volume.blend_ratios[i];
-        }, 0);
-      }
+      return values.reduce(function(intensity, current_value, i) {
+        return intensity + current_value * overlay_volume.blend_ratios[i];
+      }, 0);
     };
 
     volumes.forEach(function(volume) {
@@ -257,6 +259,16 @@
       callback(overlay_volume);
     }
   };
+
+  // Calculates the axis coordinate in world space.
+  //
+  function getSliceCoordinate(volume, axis_name) {
+    var vc = volume.getVoxelCoords();
+    var wc = volume.voxelToWorld(vc.i, vc.j, vc.k);
+
+    return wc[axis_name[0]];
+  }
+
 
   // Blend the pixels of several images using the alpha value of each
   function blendImages(images, blend_ratios, target) {


### PR DESCRIPTION
This pull request is bigger than I might have liked, but solving the main issue (#15) required a major rethinking of how we handle the overlay volume.

To make synchronization work in world coordinates, we need a voxel-to-world and world-to-voxel transform for every potentially synced volume. This means the overlay needs these transforms. The overlay uses a simple, default MINC transform. This now gives the overlay volume most of the properties and methods formerly associated only with the MINC and NIfTI-1 volumes.

I did a little code cleanup while I was at it. Fixing #194 was easy once this was working.