### PR TITLE
Improve correctness and usability of intensity reporting.

### DIFF
--- a/src/brainbrowser/volume-viewer/volume-loaders/overlay.js
+++ b/src/brainbrowser/volume-viewer/volume-loaders/overlay.js
@@ -254,36 +254,19 @@
      * the overlaid image is defined as the mean of the individual
      * volume intensities, weighted by the blend values.
      */
-    overlay_volume.getIntensityValue = function(x, y, z, time) {
-      x = x === undefined ? this.position.xspace : x;
-      y = y === undefined ? this.position.yspace : y;
-      z = z === undefined ? this.position.zspace : z;
+    overlay_volume.getIntensityValue = function(i, j, k, time) {
+      var vc = overlay_volume.getVoxelCoords();
+      i = i === undefined ? vc.i : i;
+      j = j === undefined ? vc.j : j;
+      k = k === undefined ? vc.k : k;
       time = time === undefined ? this.current_time : time;
       var values = [];
 
+      var wc = overlay_volume.voxelToWorld(i, j, k);
+
       this.volumes.forEach(function(volume) {
-        var header = volume.header;
-
-        if (x < 0 || x > header.xspace.space_length ||
-          y < 0 || y > header.yspace.space_length ||
-          z < 0 || z > header.zspace.space_length) {
-          values.push(0);
-        }
-        else {
-          var slice = volume.slice("zspace", z, time);
-          var data = slice.data;
-          var slice_x, slice_y;
-
-          if (slice.width_space.name === "xspace") {
-            slice_x = x;
-            slice_y = y;
-          } else {
-            slice_x = y;
-            slice_y = z;
-          }
-
-          values.push(data[(slice.height_space.space_length - slice_y - 1) * slice.width + slice_x]);
-        }
+        var vc = volume.worldToVoxel(wc.x, wc.y, wc.z);
+        values.push(volume.getIntensityValue(vc.i, vc.j, vc.k, time));
       });
 
       return values.reduce(function(intensity, current_value, i) {


### PR DESCRIPTION
After playing around with the intensity reporting a bit, I realized that the intensity value display was sometimes wrong in various ways.

First, I discovered that the colored background computed for the intensity values did not reflect the threshold slider position, because we were calling colorFromValue() with undefined values for the minimum and maximum intensities. A simple change causes it to reflect the selected thresholds.

Second, the intensity value was often unreadable because of low contrast between the text and the background color. I found a small code snippet that fixes this by switching between black or white foreground text as appropriate.

Next, I added two accessor functions to the volume, getVoxelMin() and getVoxelMax(), that return the absolute minimum and maximum values of the voxel data. I used them to update the UI so that we don't hard-code the idea that voxel ranges are always 0-255. I would like to relax this assumption soon.

Finally, the intensity values themselves were often wrong, especially for the overlay. I traced this to the way the coordinates are used in getIntensityValue(). I modified the generic getIntensityValue() call to use voxel coordinates to find the current intensity, then I fixed the overlay's getIntensityValue() to correctly translate from the overlay's coordinate system to each of the constituent volume's coordinates. The values should now make sense, although roundoff error in the coordinates can still cause unexpected results.

I think these comments are now longer than the actual code!