### PR TITLE
Support data wider than bytes for NIfTI images.

### DIFF
--- a/src/brainbrowser/volume-viewer/volume-loaders/minc.js
+++ b/src/brainbrowser/volume-viewer/volume-loaders/minc.js
@@ -113,7 +113,10 @@
         var width_space_offset = width_space.offset;
         var height_space_offset = height_space.offset;
 
-        var slice_data = new Uint8Array(width * height);
+        // Calling the volume data's constructor guarantees that the
+        // slice data buffer has the same type as the volume.
+        //
+        var slice_data = new volume.data.constructor(width * height);
 
         var slice;
 

--- a/src/brainbrowser/volume-viewer/volume-loaders/nifti1.js
+++ b/src/brainbrowser/volume-viewer/volume-loaders/nifti1.js
@@ -395,14 +395,14 @@
     var value = 0;              // Scaled value.
     var slope = header.scl_slope;
     var inter = header.scl_inter;
-    var n_min, n_max;
+    var n_min = +Infinity;
+    var n_max = -Infinity;
+
     // According to the NIfTI specification, a slope value of zero means
     // that the data should _not_ be scaled. Otherwise, every voxel is
     // transformed according to value = value * slope + inter
     //
     if (slope === 0.0) {
-      n_min = native_data[0];
-      n_max = native_data[0];
       for (d = 0; d < native_data.length; d++) {
         value = native_data[d];
         if (value > n_max)
@@ -413,9 +413,6 @@
     }
     else {
       var float_data = new Float32Array(native_data.length);
-
-      n_min = native_data[0] * slope + inter;
-      n_max = native_data[0] * slope + inter;
 
       for (d = 0; d < native_data.length; d++) {
         value = native_data[d] * slope + inter;

--- a/src/brainbrowser/volume-viewer/volume-loaders/nifti1.js
+++ b/src/brainbrowser/volume-viewer/volume-loaders/nifti1.js
@@ -392,37 +392,31 @@
     }
 
     var d = 0;                  // Generic loop counter.
-    var value = 0;              // Scaled value.
     var slope = header.scl_slope;
     var inter = header.scl_inter;
-    var n_min = +Infinity;
-    var n_max = -Infinity;
 
     // According to the NIfTI specification, a slope value of zero means
     // that the data should _not_ be scaled. Otherwise, every voxel is
     // transformed according to value = value * slope + inter
     //
-    if (slope === 0.0) {
-      for (d = 0; d < native_data.length; d++) {
-        value = native_data[d];
-        if (value > n_max)
-          n_max = value;
-        if (value < n_min)
-          n_min = value;
-      }
-    }
-    else {
+    if (slope !== 0.0) {
       var float_data = new Float32Array(native_data.length);
 
       for (d = 0; d < native_data.length; d++) {
-        value = native_data[d] * slope + inter;
-        if (value > n_max)
-          n_max = value;
-        if (value < n_min)
-          n_min = value;
-        float_data[d] = value;
+        float_data[d] = native_data[d] * slope + inter;
       }
       native_data = float_data; // Return the new float buffer.
+    }
+
+    var n_min = +Infinity;
+    var n_max = -Infinity;
+
+    for (d = 0; d < native_data.length; d++) {
+      var value = native_data[d];
+      if (value > n_max)
+        n_max = value;
+      if (value < n_min)
+        n_min = value;
     }
 
     header.voxel_min = n_min;

--- a/src/brainbrowser/volume-viewer/volume-loaders/overlay.js
+++ b/src/brainbrowser/volume-viewer/volume-loaders/overlay.js
@@ -177,7 +177,11 @@
         var k_size = header[header.order[2]].space_length;
 
         var data_length = max_width * max_height;
-        var slice_data = new Uint8Array(data_length);
+
+        // Calling the volume data's constructor guarantees that the
+        // slice data buffer has the same type as the volume.
+        //
+        var slice_data = new volume.data.constructor(data_length);
         var data_index = 0;
 
         // We need to calculate the slice coordinate in world


### PR DESCRIPTION
These changes allow the volume viewer to handle NIfTI-1 data that is wider than one byte. In other words, int32 or float data should be displayed using the full range of possible values, rather than being squashed into 8 bits.
