### PR TITLE
Support non-byte volumes for MINC. Also fixes #259.

### DIFF
--- a/examples/css/volume-viewer-demo.css
+++ b/examples/css/volume-viewer-demo.css
@@ -97,7 +97,8 @@ canvas.slice-display {
   -moz-box-shadow: 1px 1px 0px 0px #787878;
   -webkit-box-shadow: 1px 1px 0px 0px #787878;
   box-shadow: 1px 1px 0px 0px #787878;
-  width: 2em;
+  width: 3em;
+  font-size: 10px;
 }
 
 .coords .control-inputs {
@@ -162,5 +163,8 @@ canvas.slice-display {
 }
 
 .intensity-value {
-  padding: 1px;
+  padding: 2px;
+  -moz-border-radius: 3px;
+  -webkit-border-radius: 3px;
+  border-radius: 3px;
 }

--- a/src/brainbrowser/volume-viewer/volume-loaders/mgh.js
+++ b/src/brainbrowser/volume-viewer/volume-loaders/mgh.js
@@ -341,25 +341,14 @@
       break;
     }
 
-    var d = 0;                  // Generic loop counter.
-    var n_min = +Infinity;
-    var n_max = -Infinity;
-
-    for (d = 0; d < native_data.length; d++) {
-      if (native_data[d] > n_max)
-        n_max = native_data[d];
-      if (native_data[d] < n_min)
-        n_min = native_data[d];
-    }
-
-    header.voxel_min = n_min;
-    header.voxel_max = n_max;
+    VolumeViewer.utils.scanDataRange(native_data, header);
 
     // Incrementation offsets for each dimension of the volume. MGH
     // files store the fastest-varying dimension _first_, so the
     // "first" dimension actually has the smallest offset. That is
     // why this calculation is different from that for NIfTI-1.
     //
+    var d;
     var offset = 1;
     for (d = 0; d < header.order.length; d++) {
       header[header.order[d]].offset = offset;

--- a/src/brainbrowser/volume-viewer/volume-loaders/nifti1.js
+++ b/src/brainbrowser/volume-viewer/volume-loaders/nifti1.js
@@ -413,19 +413,7 @@
       native_data = float_data; // Return the new float buffer.
     }
 
-    var n_min = +Infinity;
-    var n_max = -Infinity;
-
-    for (d = 0; d < native_data.length; d++) {
-      var value = native_data[d];
-      if (value > n_max)
-        n_max = value;
-      if (value < n_min)
-        n_min = value;
-    }
-
-    header.voxel_min = n_min;
-    header.voxel_max = n_max;
+    VolumeViewer.utils.scanDataRange(native_data, header);
 
     if(header.order.length === 4) {
       header.order = header.order.slice(1);


### PR DESCRIPTION
This pull request incorporates several related changes:

1. Updates minc2volume-viewer.js and minc2volume-viewer.py to allow a command-line argument that sets the voxel type written to the raw file. This also adds a field to the header that indicates the voxel type.

2. Updates minc.js to read this new voxel type and act accordingly.

3. Creates a scanDataRange() utility function that is used by all volume loaders to set header.voxel_min and header.voxel_max.

4. Tweaked the example's style sheet slightly, to make room for the larger voxel values.

5. Finally, this fixes issue #259 - minc2volume-viewer.py now runs under Python 2.7.