### PR TITLE
Add a range check to avoid weird wrapping effect with negative slice_num

### DIFF
--- a/src/brainbrowser/volume-viewer/volume-loaders/minc.js
+++ b/src/brainbrowser/volume-viewer/volume-loaders/minc.js
@@ -141,17 +141,19 @@
         var i = 0;
 
         z = z_positive ? slice_num : axis_space.space_length - slice_num - 1;
-        tz_offset = time_offset + z * axis_space_offset;
+        if (z >= 0 && z < axis_space.space_length) {
+          tz_offset = time_offset + z * axis_space_offset;
 
-        for (row = height - 1; row >= 0; row--) {
-          y = y_positive ? row : height - row - 1;
-          tzy_offset = tz_offset + y * height_space_offset;
+          for (row = height - 1; row >= 0; row--) {
+            y = y_positive ? row : height - row - 1;
+            tzy_offset = tz_offset + y * height_space_offset;
 
-          for (col = 0; col < width; col++) {
-            x = x_positive ? col : width - col - 1;
-            tzyx_offset = tzy_offset + x * width_space_offset;
+            for (col = 0; col < width; col++) {
+              x = x_positive ? col : width - col - 1;
+              tzyx_offset = tzy_offset + x * width_space_offset;
 
-            slice_data[i++] = volume.data[tzyx_offset];
+              slice_data[i++] = volume.data[tzyx_offset];
+            }
           }
         }
 


### PR DESCRIPTION
@natacha-beck: While working on the BigBrain demo I found that the volume viewer has a weird bug where if you drag the cursor all the way to the left, the slice can "wrap around" to the other side of the image. I tracked it down to the fact that the UI can generate negative values for the slice number. I added a range check in minc.js that should prevent the problem for all of the volume formats.