### PR TITLE
Add getCameraPosition in surface, reset rotation when resetView

### DIFF
--- a/src/brainbrowser/surface-viewer/modules/rendering.js
+++ b/src/brainbrowser/surface-viewer/modules/rendering.js
@@ -170,6 +170,19 @@ BrainBrowser.SurfaceViewer.modules.rendering = function(viewer) {
 
   /**
   * @doc function
+  * @name viewer.rendering:getCameraPosition
+  * @description
+  * Get the camera position.
+  * ```js
+  * viewer.getCameraPosition();
+  * ```
+  */
+  viewer.getCameraPosition = function() {
+    return camera.position
+  };
+
+  /**
+  * @doc function
   * @name viewer.rendering:resetView
   * @description
   * Resets the view of the scene.
@@ -179,7 +192,7 @@ BrainBrowser.SurfaceViewer.modules.rendering = function(viewer) {
   */
   viewer.resetView = function() {
     var model = viewer.model;
-    var inv = new THREE.Matrix4();
+    var inv   = new THREE.Matrix4();
     inv.getInverse(model.matrix);
 
     model.applyMatrix(inv);
@@ -187,7 +200,7 @@ BrainBrowser.SurfaceViewer.modules.rendering = function(viewer) {
     light.position.set(0, 0, default_camera_distance);
 
     model.children.forEach(function(shape) {
-      var centroid = shape.userData.centroid;
+      var centroid   = shape.userData.centroid;
       var recentered = shape.userData.recentered;
 
       // The check for original_data tells us
@@ -208,6 +221,7 @@ BrainBrowser.SurfaceViewer.modules.rendering = function(viewer) {
       }
     });
 
+    model.rotation.set(0, 0, 0);
     viewer.zoom = 1;
 
     viewer.updated = true;


### PR DESCRIPTION
@bert: Can you take a look to this short PR. I need to have a getCameraPosition in order to integrate the new MACACC dataset.
In this way I can keep the same position when I switch between MACACC-1 and MACACC-2. 