### PR TITLE
Allow volume loaders to parse sources directly

### DIFF
--- a/src/brainbrowser/volume-viewer/volume-loaders/mgh.js
+++ b/src/brainbrowser/volume-viewer/volume-loaders/mgh.js
@@ -60,9 +60,13 @@
           createMGHVolume(header, data, callback);
         });
       }, {result_type: "arraybuffer" });
+    } else if (description.source) {
+      parseMGHHeader(description.source, function(header) {
+        createMGHVolume(header, description.source, callback);
+      });
     } else {
       error_message = "invalid volume description.\n" +
-        "Description must contain the property 'url' or 'file'.";
+        "Description must contain the property 'url', 'file' or 'source'.";
 
       BrainBrowser.events.triggerEvent("error", { message: error_message });
       throw new Error(error_message);

--- a/src/brainbrowser/volume-viewer/volume-loaders/minc.js
+++ b/src/brainbrowser/volume-viewer/volume-loaders/minc.js
@@ -49,10 +49,14 @@
           }, { result_type: "arraybuffer" });
         });
       });
+    } else if (description.header_source && description.raw_data_source) {
+      parseHeader(description.header_source, function(header) {
+        createMincVolume(header, description.raw_data_source, callback);
+      });
     } else {
       error_message = "invalid volume description.\n" +
-        "Description must contain property pair 'header_url' and 'raw_data_url', or\n" +
-        "'header_file' and 'raw_data_file'.";
+        "Description must contain property pair 'header_url' and 'raw_data_url', \n" +
+        "'header_file' and 'raw_data_file' \nor 'header_source' and 'raw_data_source'.";
 
       BrainBrowser.events.triggerEvent("error", { message: error_message });
       throw new Error(error_message);
@@ -509,7 +513,7 @@
     header.zspace.direction_cosines = header.zspace.direction_cosines.map(parseFloat);
 
     /* Incrementation offsets for each dimension of the volume.
-     * Note that this somewhat format-specific, so it does not 
+     * Note that this somewhat format-specific, so it does not
      * belong in the generic "createVolume()" code.
      */
     header[header.order[0]].offset = header[header.order[1]].space_length * header[header.order[2]].space_length;

--- a/src/brainbrowser/volume-viewer/volume-loaders/nifti1.js
+++ b/src/brainbrowser/volume-viewer/volume-loaders/nifti1.js
@@ -49,9 +49,13 @@
           createNifti1Volume(header, nii_data, callback);
         });
       }, {result_type: "arraybuffer" });
+    } else if (description.nii_source) {
+      parseNifti1Header(description.nii_source, function(header) {
+        createNifti1Volume(header, description.nii_source, callback);
+      });
     } else {
       error_message = "invalid volume description.\n" +
-        "Description must contain the property 'nii_url' or 'nii_file'.";
+        "Description must contain the property 'nii_url' or 'nii_file' or 'nii_source'.";
 
       BrainBrowser.events.triggerEvent("error", { message: error_message });
       throw new Error(error_message);


### PR DESCRIPTION
## Feature

Allows a third way to load volumes: by directly providing the source data.

```javascript
var buffer = ArrayBuffer();
var callback = function (volume) { };

BrainBrowser.VolumeViewer.volume_loaders.nifti1({
    'nii_source': buffer,
    'type': 'nifti1'
}, callback);
```

## Why

I need to load volumes files from a secured server that requires authentification (so custom headers on HTTP requests). The *BrainBrowser.loader:loadFromURL* does not allow me to modify request headers easily.
So I'd rather handle the downloading on volumes files myself, and rely on the volumes loaders for their core feature: parsing and manipulating the data.

## Implementation

The implementation is quite simple, generic and non-intrusive:
- It allows a third option named `source` (or `nii_source` for nifti files and `header_source` and `raw_data_source` for minc files, to follow their respective naming pattern).
- It's backward compatible.
- Tests are passing (I did not add specific tests on my feature yet though).
- I tried to be consistent with the coding style.


## Questions

I'm not sure whether or not I should commit the following built files:
- build/brainbrowser-2.4.1/brainbrowser.volume-viewer.min.js
- release/brainbrowser-2.4.1.tar.gz

## Final thoughts

I would have used `parseNifti1Header` and `createNifti1Volume` but they're scoped and inaccessible.