### PR TITLE
Several changes to improve zooming behaviour.

### DIFF
--- a/examples/volume-viewer-demo.js
+++ b/examples/volume-viewer-demo.js
@@ -285,6 +285,13 @@ $(function() {
       });
     });
 
+    $(document).keypress(function(e) {
+      if (e.keyCode === 114) {
+        // Reset displays if user presses 'r' key.
+        viewer.resetDisplays();
+        viewer.redrawVolumes();
+      }
+    });
     //////////////////////////////////
     // Per volume UI hooks go in here.
     //////////////////////////////////

--- a/src/brainbrowser/volume-viewer/lib/panel.js
+++ b/src/brainbrowser/volume-viewer/lib/panel.js
@@ -295,9 +295,10 @@
       * ```
       */
       reset: function() {
-        panel.zoom = 1;
+        panel.zoom = panel.default_zoom;
         panel.image_center.x = panel.canvas.width / 2;
         panel.image_center.y = panel.canvas.height / 2;
+        panel.updated = true;
       },
 
       /**
@@ -496,8 +497,10 @@
     }
 
     if (panel.volume) {
-      setSlice(panel, panel.volume.slice(panel.axis));
-      panel.zoom = panel.volume.getPreferredZoom(panel.canvas.width, panel.canvas.height);
+      var volume = panel.volume;
+      setSlice(panel, volume.slice(panel.axis));
+      panel.default_zoom = volume.getPreferredZoom(panel.canvas.width, panel.canvas.height);
+      panel.zoom = panel.default_zoom;
     }
 
     return panel;
@@ -518,7 +521,7 @@
     var context = panel.context;
     var cursor = panel.getCursorPosition();
     var zoom = panel.zoom;
-    var length = 8 * zoom;
+    var length = 8 * (zoom / panel.default_zoom);
     var x, y, space;
     var distance;
     var dx, dy;
@@ -529,7 +532,7 @@
     context.strokeStyle = color;
     context.fillStyle = color;
 
-    space = zoom;
+    space = 1;
     x = cursor.x;
     y = cursor.y;
 

--- a/src/brainbrowser/volume-viewer/lib/panel.js
+++ b/src/brainbrowser/volume-viewer/lib/panel.js
@@ -497,6 +497,7 @@
 
     if (panel.volume) {
       setSlice(panel, panel.volume.slice(panel.axis));
+      panel.zoom = panel.volume.getPreferredZoom(panel.canvas.width, panel.canvas.height);
     }
 
     return panel;

--- a/src/brainbrowser/volume-viewer/modules/loading.js
+++ b/src/brainbrowser/volume-viewer/modules/loading.js
@@ -646,7 +646,7 @@ BrainBrowser.VolumeViewer.modules.loading = function(viewer) {
 
           last_touch_distance = null;
         }
-        
+
         canvas.addEventListener("mousedown", function(event) {
           event.preventDefault();
 
@@ -696,7 +696,8 @@ BrainBrowser.VolumeViewer.modules.loading = function(viewer) {
         }
 
         function zoom(delta) {
-          panel.zoom = Math.max(panel.zoom + delta * 0.05, 0.05);
+          panel.zoom *= (delta < 0) ? 1/1.05 : 1.05;
+          panel.zoom = Math.max(panel.zoom, 0.25);
           panel.updateVolumePosition();
           panel.updateSlice();
 

--- a/src/brainbrowser/volume-viewer/volume-loaders/minc.js
+++ b/src/brainbrowser/volume-viewer/volume-loaders/minc.js
@@ -372,6 +372,21 @@
       },
       getVoxelMax: function() {
         return volume.header.voxel_max;
+      },
+      /* given a width and height (from the panel), this function returns the "best"
+       * single zoom level that will guarantee that the image fits exactly into the
+       * current panel.
+       */
+      getPreferredZoom: function(width, height) {
+        var header = volume.header;
+        var x_fov = header.xspace.space_length * Math.abs(header.xspace.step);
+        var y_fov = header.yspace.space_length * Math.abs(header.yspace.step);
+        var z_fov = header.zspace.space_length * Math.abs(header.xspace.step);
+        var xw = width / x_fov;
+        var yw = width / y_fov;
+        var yh = height / y_fov;
+        var zh = height / z_fov;
+        return Math.min(yw, xw, zh, yh);
       }
     };
     return volume;


### PR DESCRIPTION
This collects several small changes. One of the main goals is to make the volume viewer more usable with smaller field-of-view images such as mouse brains.

1. For the volume viewer demo, use the 'r' key to reset the view.
2. When resetting, reset zoom to the computed "preferred" or default value.
3. Compute the preferred zoom when the volume is loaded.
4. Draw the cursor with a fixed line width, so that it doesn't get absurdly thick at high zoom levels.
5. Use multiplicative rather than additive calculation when zooming, to improve responsiveness at high zoom levels.