### PR TITLE
Use pako.js to inflate gzipped files through loadFromFile().

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -122,7 +122,8 @@ module.exports = function(grunt) {
             BrainBrowser: true,
             alert: true,
             console: true,
-            pako: true
+            pako: true,
+            TextDecoder: true
           }
         },
         src: [

--- a/examples/surface-viewer-demo.html
+++ b/examples/surface-viewer-demo.html
@@ -218,6 +218,7 @@
     <script src="js/jquery-1.6.4.min.js"></script>
     <script src="js/jquery-ui-1.8.10.custom.min.js"></script>
     <script src="js/ui.js"></script>
+    <script src="js/pako.js"></script>
     <script src="js/brainbrowser/brainbrowser.js"></script>
     <script src="js/brainbrowser/core/tree-store.js"></script>
     <script src="js/brainbrowser/lib/config.js"></script>


### PR DESCRIPTION
These changes will allow loading of gzipped files through the loadFromFile() interface of the BrainBrowser. The code uses pako.js to inflate either string or binary data.