### PR TITLE
Fix #312, force the expected ordering of scans in volume viewer.

### DIFF
--- a/src/brainbrowser/volume-viewer.js
+++ b/src/brainbrowser/volume-viewer.js
@@ -278,6 +278,7 @@
     * @name viewer
     * @property {array} volumes Volumes to be displayed.
     * @property {boolean} synced Are the cursors being synced across volumes?
+    * @property {array} containers The div containers for each volume.
     * @property {DOMElement} dom_element The DOM element where the viewer
     * will be inserted.
     * @property {active_panel} active_panel The slice panel that's currently
@@ -316,6 +317,7 @@
     var viewer = {
       dom_element: dom_element,
       volumes: [],
+      containers: [],
       synced: false
     };
 

--- a/src/brainbrowser/volume-viewer/modules/loading.js
+++ b/src/brainbrowser/volume-viewer/modules/loading.js
@@ -726,11 +726,15 @@ BrainBrowser.VolumeViewer.modules.loading = function(viewer) {
      * to be sure that this container is inserted before the subsequent
      * container. This guarantees the ordering of elements.
      */
-    var next_id = vol_id + 1;
-    if (next_id in viewer.containers) {
-      dom_element.insertBefore(container, viewer.containers[next_id]);
+    var containers = viewer.containers;
+    var next_id;
+    for (next_id = vol_id + 1; next_id < containers.length; next_id++) {
+      if (next_id in containers) {
+        dom_element.insertBefore(container, containers[next_id]);
+        break;
+      }
     }
-    else {
+    if (next_id === containers.length) {
       dom_element.appendChild(container);
     }
     viewer.triggerEvent("volumeuiloaded", {

--- a/src/brainbrowser/volume-viewer/modules/loading.js
+++ b/src/brainbrowser/volume-viewer/modules/loading.js
@@ -291,6 +291,7 @@ BrainBrowser.VolumeViewer.modules.loading = function(viewer) {
     });
 
     viewer.volumes = [];
+    viewer.containers = [];
     viewer.active_panel = null;
     viewer.dom_element.innerHTML = "";
   };
@@ -719,7 +720,19 @@ BrainBrowser.VolumeViewer.modules.loading = function(viewer) {
       });
     })();
 
-    dom_element.appendChild(container);
+    viewer.containers[vol_id] = container;
+
+    /* See if a subsequent volume has already been loaded. If so we want
+     * to be sure that this container is inserted before the subsequent
+     * container. This guarantees the ordering of elements.
+     */
+    var next_id = vol_id + 1;
+    if (next_id in viewer.containers) {
+      dom_element.insertBefore(container, viewer.containers[next_id]);
+    }
+    else {
+      dom_element.appendChild(container);
+    }
     viewer.triggerEvent("volumeuiloaded", {
       container: container,
       volume: volume,


### PR DESCRIPTION
This should fix the long-standing issue that the volume viewer ordering of volumes is non-deterministic.

The solution is to use "insertBefore()", where possible, to insert the div element of a new volume before a subsequent volume when appropriate. The change is fairly small