### PR TITLE
Fix #332, correctly handle HDF5 files with impossible values for data offset in the layout message.

### DIFF
--- a/src/brainbrowser/volume-viewer/volume-loaders/hdf5.js
+++ b/src/brainbrowser/volume-viewer/volume-loaders/hdf5.js
@@ -1884,7 +1884,8 @@
     }
 
     function loadData(link) {
-      if (link.chunk_size !== 0) {
+      if (link.chunk_size !== 0 &&
+          link.data_offset > 0 && link.data_offset < superblk.eof_addr) {
         seek(link.data_offset);
 
         var n_bytes = 1;


### PR DESCRIPTION
HDF5 often uses indirection through pointers to refer to data areas in files. Many files have empty data areas, and this is often indicated by setting the associated pointer to an impossible value. This was one place where I was not checking for that possibility, and so certain files would not load properly.