### PR TITLE
Another fix for #332, avoid reading past valid link records.

### DIFF
--- a/src/brainbrowser/volume-viewer/volume-loaders/hdf5.js
+++ b/src/brainbrowser/volume-viewer/volume-loaders/hdf5.js
@@ -1060,7 +1060,11 @@
         var fh = hdf5FractalHeapHeader();
         var n_msg = 0;
         hdf5FractalHeapEnumerate( fh, function(row, address, block_offset, block_length) {
-          var end_address = address + block_length;
+          /* Avoid errors caused by extra alignment bytes by
+           * ignoring the last few bytes in the block, if
+           * present.
+           */
+          var end_address = address + block_length - 4;
           while (n_msg < fh.heap_nobj && tell() < end_address) {
             hdf5MsgLink(link);
             n_msg += 1;


### PR DESCRIPTION
@natacha-beck This should fix Mouna's new issue.

Long story short, these new files have some extra padding or alignment bytes that I was incorrectly trying to read as HDF5 "link" records. With this small change all of the files from Mouna's example now load.