### PR TITLE
Fix/readme setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ To set up WSL:
 ```
 
 7. Now run all these commands in the WSL terminal:
-   ```Shell
+```Shell
   $ git clone https://github.com/aces/brainbrowser.git
   $ npm install --legacy-peer-deps
   $ npm install -g grunt-cli

--- a/README.md
+++ b/README.md
@@ -56,7 +56,15 @@ To set up WSL:
    $ ln -s ../../src/brainbrowser examples/js/brainbrowser
 ```
 
-7. Now run all the setup commands provided above inside the WSL terminal.
+7. Now run all these commands in the WSL terminal:
+   ```Shell
+  $ git clone https://github.com/aces/brainbrowser.git
+  $ npm install --legacy-peer-deps
+  $ npm install -g grunt-cli
+  $ grunt compile
+  $ npm install -g nano-server
+  $ nano-server 5000 examples
+```
 
 
 Note that [nano-server](https://www.npmjs.org/package/nano-server) is recommended because it can send **gzip** compressed versions of requested files. If a server without this functionality is used, files in **brainbrowser/examples/models/** and **brainbrowser/examples/color-maps/** will have to be **gunzipped**.

--- a/README.md
+++ b/README.md
@@ -16,13 +16,52 @@ To try out some BrainBrowser sample applications, simply clone this git repo, an
 
 ```Shell
   $ git clone https://github.com/aces/brainbrowser.git
+  $ npm install --legacy-peer-deps
+  $ npm install -g grunt-cli
+  $ grunt compile
   $ npm install -g nano-server
-  $ nano-server 5000 brainbrowser/examples
+  $ nano-server 5000 examples
 ```
+
+### Windows Users
+
+Windows users must use **WSL (Windows Subsystem for Linux)** because the project uses a Unix symlink (`examples/js/brainbrowser → src/brainbrowser`) that does not work natively on Windows. When git clones the repository on Windows, this symlink is checked out as a plain 23-byte text file instead of an actual directory link. This causes both viewers to show a blank black screen with 404 errors in the browser console because none of the JS files can be found.
+
+To set up WSL:
+
+1. Open PowerShell as Administrator and run:
+```Shell
+   $ wsl --install
+```
+
+2. After completing all the installtaions restart your computer.
+
+3. Open **Ubuntu** from the Start menu and set up your username and password.
+
+4. Install Node.js inside WSL (WSL has its own separate environment and does not use your Windows Node.js installation):
+```Shell
+   $ curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash -
+   $ sudo apt-get install -y nodejs
+```
+
+5. Navigate to your project inside WSL (Windows drives are mounted under `/mnt/`):
+```Shell
+   $ cd /mnt/path/to/brainbrowser
+```
+
+6. Fix the Unix symlink. When git clones on Windows, the symlink `examples/js/brainbrowser` is saved as a plain text file containing the path `../../src/brainbrowser` instead of acting as a real directory link. This must be manually recreated as a proper Linux symlink inside WSL:
+```Shell
+   $ rm examples/js/brainbrowser
+
+   $ ln -s ../../src/brainbrowser examples/js/brainbrowser
+```
+
+7. Now run all the setup commands provided above inside the WSL terminal.
+
 
 Note that [nano-server](https://www.npmjs.org/package/nano-server) is recommended because it can send **gzip** compressed versions of requested files. If a server without this functionality is used, files in **brainbrowser/examples/models/** and **brainbrowser/examples/color-maps/** will have to be **gunzipped**.
 
-Once the server is running, navigate to to appropriate address (localhost:5000 in the above example) in your browser and select either of the **Surface Viewer** or **Volume Viewer** sample applications.
+Once the server is running, navigate to appropriate address (localhost:5000 in the above example) in your browser and select either of the **Surface Viewer** or **Volume Viewer** sample applications.
 
 Surface Viewer
 --------------


### PR DESCRIPTION
While trying to start the brainbrowser on my pc I faced certain issues and realized that due to the brainbrowser old packages they conflict with modern npm and thus the current README instructions are not enough for new users to run this project as there are some commands that we need to use in order to run this project the brief description about the problems is:
## Problems Found
Missing `npm install --legacy-peer-deps` old packages conflict with modern npm's strict dependency rules causing an    ERESOLVE error
Missing `npm install -g grunt-cli` without this grunt command is not found
Missing `grunt compile` without this both viewers show a black screen with 404 errors in the browser console `grunt build` fails on modern Node.js due to broken test suite
No documentation for Windows users Unix symlink silently breaks on Windows causing 404 errors with no explanation.
## Changes Made
Added all missing setup commands
Added Windows/WSL section with symlink fix
FIxed some typos in README