### PR TITLE
fix: broken grunt test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ examples/models/*.header
 examples/models/*.headers
 examples/models/*.raw
 examples/models/*.json
+package-lock.json

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -22,7 +22,7 @@
 * Author: Tarek Sherif  <tsherif@gmail.com> (http://tareksherif.ca/)
 */
 
-module.exports = function(grunt) {
+module.exports = function (grunt) {
   "use strict";
 
   grunt.initConfig({
@@ -61,15 +61,15 @@ module.exports = function(grunt) {
       options: {
         report: "min",
         banner: "<%= license %>\n" +
-                "/*\n" +
-                "* BrainBrowser v<%= pkg.version %>\n" +
-                "*\n" +
-                "* Author: Tarek Sherif  <tsherif@gmail.com> (http://tareksherif.ca/)\n" +
-                "* Author: Nicolas Kassis\n" +
-                "* Author: Paul Mougel\n" +
-                "*\n" +
-                "* three.js (c) 2010-2014 three.js authors, used under the MIT license\n" +
-                "*/\n"
+          "/*\n" +
+          "* BrainBrowser v<%= pkg.version %>\n" +
+          "*\n" +
+          "* Author: Tarek Sherif  <tsherif@gmail.com> (http://tareksherif.ca/)\n" +
+          "* Author: Nicolas Kassis\n" +
+          "* Author: Paul Mougel\n" +
+          "*\n" +
+          "* three.js (c) 2010-2014 three.js authors, used under the MIT license\n" +
+          "*/\n"
       },
       surface: {
         files: {
@@ -191,8 +191,24 @@ module.exports = function(grunt) {
         src: "brainbrowser-<%= BRAINBROWSER_VERSION %>/**"
       }
     },
+    connect: {
+      server: {
+        options: {
+          port: 8000,
+          base: "."
+        }
+      }
+    },
     qunit: {
-      all: ["test/*.html"]
+      all: {
+        options: {
+          puppeteer: {
+            args: ["--no-sandbox", "--disable-setuid-sandbox"]
+          },
+          httpBase: "http://localhost:8000"
+        },
+        src: ["test/*.html"]
+      }
     },
     docular: {
       docular_webapp_target: "docs/docular",
@@ -225,6 +241,7 @@ module.exports = function(grunt) {
   });
 
   grunt.loadNpmTasks("grunt-contrib-uglify");
+  grunt.loadNpmTasks("grunt-contrib-connect");
   grunt.loadNpmTasks("grunt-contrib-jshint");
   grunt.loadNpmTasks("grunt-contrib-concat");
   grunt.loadNpmTasks("grunt-contrib-clean");
@@ -234,7 +251,7 @@ module.exports = function(grunt) {
 
   grunt.registerTask("compile", ["clean", "concat", "uglify"]);
   grunt.registerTask("build", ["test", "compile", "compress"]);
-  grunt.registerTask("test", ["jshint", "qunit"]);
+  grunt.registerTask("test", ["jshint", "connect", "qunit"]);
   grunt.registerTask("docs", ["docular", "clean:docs"]);
   grunt.registerTask("default", "test");
 };

--- a/examples/bigbrain-viewer-demo.js
+++ b/examples/bigbrain-viewer-demo.js
@@ -2070,7 +2070,7 @@ $(function() {
         var j=0;
 
         if ((viewer.model.children.length !== 0) && (user_defined_grid_length === "no")){
-          for (i = 0; i < m1_model_data_get.shapes.length; i++) {
+          for (var i = 0; i < m1_model_data_get.shapes.length; i++) {
             if ((viewer.model.children[i].name !== "axes") && (viewer.model.children[i].name !== "marker") && (viewer.model.children[i].name !== "grid")){
               // Include this shape for computing bounding box of visible shapes if opacity >25% and if not turned off
               if ((viewer.model.children[i].material.opacity > 0.25) && (document.getElementById("opacity-slider-" + i).style.visibility !== "hidden")){
@@ -2092,7 +2092,7 @@ $(function() {
           }
 
           if ( m > 1 ) {
-            for (var i = m1_model_data_get.shapes.length; i < (m1_model_data_get.shapes.length + m2_model_data_get.shapes.length); i++) {
+            for (i = m1_model_data_get.shapes.length; i < (m1_model_data_get.shapes.length + m2_model_data_get.shapes.length); i++) {
               if ((viewer.model.children[i].name !== "axes") && (viewer.model.children[i].name !== "marker") && (viewer.model.children[i].name !== "grid")){
                 if ((viewer.model.children[i].material.opacity > 0.25) && (document.getElementById("opacity-slider-" + i).style.visibility !== "hidden")){ //Include this shape for computing bounding box of visible shapes if opacity >25% and if not turned off
                   bounding_box_min_x[i] = m2_model_data_get.shapes[j].bounding_box.min_x;

--- a/package.json
+++ b/package.json
@@ -4,16 +4,18 @@
   "license": "GNU Affero GPL 3.0",
   "devDependencies": {
     "bower": "~1.8.8",
-    "grunt": "^1.3.0",
-    "grunt-contrib-jshint": "~0.6.4",
-    "grunt-contrib-uglify": "~0.2.4",
-    "grunt-contrib-concat": "~0.3.0",
-    "grunt-contrib-clean": "~0.5.0",
+    "grunt": "^1.6.1",
+    "grunt-contrib-connect": "^3.0.0",
+    "grunt-contrib-jshint": "^3.2.0",
+    "grunt-contrib-uglify": "^5.2.2",
+    "grunt-contrib-concat": "^2.1.0",
+    "grunt-contrib-clean": "^2.0.1",
     "grunt-docular": "~0.1.2",
-    "grunt-contrib-compress": "~0.5.3",
-    "grunt-contrib-qunit": "~0.5.1"
+    "grunt-contrib-compress": "^2.0.0",
+    "grunt-contrib-qunit": "^9.0.0",
+    "qunit": "^2.21.0"
   },
-  "scripts" : {
-      "test": "grunt"
+  "scripts": {
+    "test": "grunt"
   }
 }

--- a/test/event-model-test.html
+++ b/test/event-model-test.html
@@ -27,12 +27,12 @@
 <head>
   <meta charset="utf-8">
   <title>BrainBrowser Event Model Tests</title>
-  <link rel="stylesheet" href="lib/qunit-1.14.0.css">
+<link rel="stylesheet" href="../node_modules/qunit/qunit/qunit.css">
 </head>
 <body>
   <div id="qunit"></div>
   <div id="qunit-fixture"></div>
-  <script src="lib/qunit-1.14.0.js"></script>
+  <script src="../node_modules/qunit/qunit/qunit.js"></script>
   <script src="brainbrowser/brainbrowser.js"></script>
   <script src="brainbrowser/lib/utils.js"></script> 
   <script src="brainbrowser/lib/events.js"></script> 

--- a/test/tree-store-test.html
+++ b/test/tree-store-test.html
@@ -27,12 +27,12 @@
 <head>
   <meta charset="utf-8">
   <title>BrainBrowser Tree Store Tests</title>
-  <link rel="stylesheet" href="lib/qunit-1.14.0.css">
+  <link rel="stylesheet" href="../node_modules/qunit/qunit/qunit.css">
 </head>
 <body>
   <div id="qunit"></div>
   <div id="qunit-fixture"></div>
-  <script src="lib/qunit-1.14.0.js"></script>
+  <script src="../node_modules/qunit/qunit/qunit.js"></script>
   <script src="brainbrowser/brainbrowser.js"></script>
   <script src="brainbrowser/core/tree-store.js"></script>
   <script src="tree-store-test.js"></script>


### PR DESCRIPTION
`grunt test` was broken on modern Node.js with the following error:
Fatal error: The "cb" argument must be of type function. Received undefined

The dependencies on which the grunt test depends were outdated which led to this error. I fixed that by updating those dependencies via npm:
Upgraded grunt-contrib-qunit to latest version which now uses headless Chrome instead of abandoned phantomjs.

Added qunit as a devDependency in package.json.

Updated test HTML files to reference QUnit from node_modules so now the test will always use the npm managed version.

Added `grunt-contrib-connect` to serve files over HTTP for headless Chrome (required as Chrome cannot load files directly from filesystem like phantomjs).

Updated Gruntfile.js to use puppeteer with no-sandbox flags for headless Chrome compatibility

Fixed a pre-existing jshint scope error in `examples/bigbrain-viewer-demo.js` that was blocking grunt test from completing

**Before**
<img width="791" height="369" alt="Screenshot 2026-03-19 114916" src="https://github.com/user-attachments/assets/1d367186-1a83-4914-a490-c5b25db3fb58" />

**After**
<img width="610" height="413" alt="qunit proper update " src="https://github.com/user-attachments/assets/e0f88517-1a04-46ab-9f36-057b48a16ab3" />

